### PR TITLE
Fix issue #19

### DIFF
--- a/src/main/java/com/shipengine/InternalClient.java
+++ b/src/main/java/com/shipengine/InternalClient.java
@@ -436,7 +436,7 @@ public class InternalClient {
         switch (statusCode) {
             case 400:
             case 500:
-                Map<String, ArrayList<Map<String, String>>> responseBody400And500 = apiResponseToMap(httpResponseBody);
+                Map<String, Object> responseBody400And500 = apiResponseToMap(httpResponseBody);
                 Map<String, String> error400And500 = responseBody400And500.get("errors").get(0);
                 throw new ShipEngineException(
                         error400And500.get("message"),


### PR DESCRIPTION
Your response return Map<String, String+ArrayList>:

![unknown](https://user-images.githubusercontent.com/108881014/194827409-522f9fef-b564-49d7-bf05-dd7a8e00fb9a.png)

In src/main/java/com/shipengine/InternalClient.java
func checkResponseForErrors( )
you initiate a Map<String, ArrayList> to get that response:

![11unk11nown](https://user-images.githubusercontent.com/108881014/194827472-ca098698-61dc-4fa5-908f-83cbfbf296ee.png)

then this ClassCastException show up (should be ShipengineException)
class java.lang.String cannot be cast to class java.util.ArrayList (java.lang.String and java.util.ArrayList are in module java.base of loader 'bootstrap')