### PR TITLE
 Fix issue #19

### DIFF
--- a/src/main/java/com/shipengine/InternalClient.java
+++ b/src/main/java/com/shipengine/InternalClient.java
@@ -437,7 +437,7 @@ public class InternalClient {
             case 400:
             case 500:
                 Map<String, Object> responseBody400And500 = apiResponseToMap(httpResponseBody);
-                Map<String, String> error400And500 = responseBody400And500.get("errors").get(0);
+                Map<String, String> error400And500 = (Map) ((ArrayList) responseBody400And500.get("errors")).get(0);
                 throw new ShipEngineException(
                         error400And500.get("message"),
                         responseBody400And500.get("request_id").toString(),
@@ -446,12 +446,9 @@ public class InternalClient {
                         error400And500.get("error_code")
                 );
             case 404:
-                Map<String, ArrayList<Map<String, String>>> responseBody404 = httpResponseBody.equals("") ?
-                        Map.of() :
-                        apiResponseToMap(httpResponseBody);
-                Map<String, String> error404 = responseBody404.containsKey("errors") ?
-                        responseBody404.get("errors").get(0) :
-                        Map.of();
+                Map<String, Object> responseBody404 = httpResponseBody.equals("") ? Map.of() : apiResponseToMap(httpResponseBody);
+                Map<String, String> error404 = responseBody404.containsKey("errors") ? (Map) ((ArrayList) responseBody404.get("errors")).get(0) : Map.of();
+                
                 throw new ShipEngineException(
                         mapSizeIsNotZero(error404) ? error404.get("message") : "404 Error Occurred..",
                         responseBody404.size() != 0 ? responseBody404.get("request_id").toString() : "",

--- a/src/main/java/com/shipengine/InternalClient.java
+++ b/src/main/java/com/shipengine/InternalClient.java
@@ -436,7 +436,7 @@ public class InternalClient {
         switch (statusCode) {
             case 400:
             case 500:
-                Map<String, ArrayList<Map<String, String>>> responseBody400And500 = apiResponseToMap(httpResponseBody);
+                Map<String, Object> responseBody400And500 = apiResponseToMap(httpResponseBody);
                 Map<String, String> error400And500 = responseBody400And500.get("errors").get(0);
                 throw new ShipEngineException(
                         error400And500.get("message"),


### PR DESCRIPTION
Issue https://github.com/ShipEngine/shipengine-java/issues/19
Your response return Map<String, String+ArrayList>:

![unknown](https://user-images.githubusercontent.com/108881014/195574015-b967c207-a22f-4724-a65f-b772058bee46.png)

In src/main/java/com/shipengine/InternalClient.java
func checkResponseForErrors( )
you initiate a Map<String, ArrayList> to get that response:

![11unk11nown](https://user-images.githubusercontent.com/108881014/195574039-1abfaa0a-ddd6-42f8-8972-c529a922613a.png)

then this ClassCastException's thrown (should be ShipengineException)

class java.lang.String cannot be cast to class java.util.ArrayList (java.lang.String and java.util.ArrayList are in module java.base of loader 'bootstrap')

I suggest using Object instead of ArrayList.
Work just fine for me.