### PR TITLE
Added error codes for funding sources errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,28 @@
 
 ## [1.0.3](https://github.com/ShipEngine/shipengine-java/compare/v1.0.2...v1.0.3) (2024-01-17)
 
-
 ### Bug Fixes
 
-* update timeout to 60s ([f8bca01](https://github.com/ShipEngine/shipengine-java/commit/f8bca01e115aba99343f64de30282c25c13ea045))
+- update timeout to 60s ([f8bca01](https://github.com/ShipEngine/shipengine-java/commit/f8bca01e115aba99343f64de30282c25c13ea045))
 
 ## 1.0.2 (2022-10-21)
 
-
 ### Bug Fixes
 
-* Fixed exception handling
-* Fixed bug in deriveUserAgent method in the InternalClient now reads sdk version from resources/project.properties instead of version.txt. ([2aa3d13](https://github.com/ShipEngine/shipengine-java/commit/2aa3d133756cfb311beb10bec3474dfad91bffef))
-* Testing and linting working CI ([748d2ce](https://github.com/ShipEngine/shipengine-java/commit/748d2ceced376e0d66f895f5251ba166e70d9c5f))
-* Updated pom.xml settings to fix JaCoCo coverage reporting bug. ([a91ef99](https://github.com/ShipEngine/shipengine-java/commit/a91ef99f29adf74e99478cc248291731be38ddff))
+- Fixed exception handling
+- Fixed bug in deriveUserAgent method in the InternalClient now reads sdk version from resources/project.properties instead of version.txt. ([2aa3d13](https://github.com/ShipEngine/shipengine-java/commit/2aa3d133756cfb311beb10bec3474dfad91bffef))
+- Testing and linting working CI ([748d2ce](https://github.com/ShipEngine/shipengine-java/commit/748d2ceced376e0d66f895f5251ba166e70d9c5f))
+- Updated pom.xml settings to fix JaCoCo coverage reporting bug. ([a91ef99](https://github.com/ShipEngine/shipengine-java/commit/a91ef99f29adf74e99478cc248291731be38ddff))
 
 ## 1.0.3
 
 ### Changes
 
-* increase default timeout to 60s
+- increase default timeout to 60s
+
+## 1.0.4
+
+### Changes
+
+- Added error code FundingSourceMissingConfiguration
+- Added error code FundingSourceError

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.shipengine</groupId>
   <artifactId>shipengine</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
 
   <name>ShipEngine SDK</name>
   <description>The official Java SDK for ShipEngine API.</description>

--- a/src/main/java/com/shipengine/exception/ShipEngineException.java
+++ b/src/main/java/com/shipengine/exception/ShipEngineException.java
@@ -81,7 +81,9 @@ public class ShipEngineException extends RuntimeException {
         UNSPECIFIED,
         VERIFICATION_CONFLICT,
         WAREHOUSE_CONFLICT,
-        WEBHOOK_EVENT_TYPE_CONFLICT
+        WEBHOOK_EVENT_TYPE_CONFLICT,
+        FUNDING_SOURCE_MISSING_CONFIGURATION,
+        FUNDING_SOURCE_ERROR
     }
 
     /**
@@ -96,7 +98,8 @@ public class ShipEngineException extends RuntimeException {
      * contact ShipEngine for support or if you should contact the carrier or
      * marketplace instead.
      *
-     * @see <a href="https://www.shipengine.com/docs/errors/codes/#error-source">...</a>
+     * @see <a href=
+     *      "https://www.shipengine.com/docs/errors/codes/#error-source">...</a>
      */
     private ErrorSource source;
 
@@ -104,7 +107,8 @@ public class ShipEngineException extends RuntimeException {
      * Indicates the type of error that occurred, such as a validation error, a
      * security error, etc.
      *
-     * @see <a href="https://www.shipengine.com/docs/errors/codes/#error-type">...</a>
+     * @see <a href=
+     *      "https://www.shipengine.com/docs/errors/codes/#error-type">...</a>
      */
     private ErrorType type;
 
@@ -112,7 +116,8 @@ public class ShipEngineException extends RuntimeException {
      * A code that indicates the specific error that occurred, such as missing a
      * required field, an invalid address, a timeout, etc.
      *
-     * @see <a href="https://www.shipengine.com/docs/errors/codes/#error-code">...</a>
+     * @see <a href=
+     *      "https://www.shipengine.com/docs/errors/codes/#error-code">...</a>
      */
     private ErrorCode code;
 
@@ -172,8 +177,7 @@ public class ShipEngineException extends RuntimeException {
             ErrorSource source,
             ErrorType type,
             ErrorCode code,
-            String url
-    ) {
+            String url) {
         super(message);
         setRequestID(requestID);
         setSource(source);
@@ -187,8 +191,7 @@ public class ShipEngineException extends RuntimeException {
             ErrorSource source,
             ErrorType type,
             ErrorCode code,
-            String url
-    ) {
+            String url) {
         super(message);
         setSource(source);
         setType(type);
@@ -201,8 +204,7 @@ public class ShipEngineException extends RuntimeException {
             String requestID,
             String source,
             String type,
-            String code
-    ) {
+            String code) {
         super(message);
         setRequestID(requestID);
         setSource(ErrorSource.valueOf(source.toUpperCase()));
@@ -214,8 +216,7 @@ public class ShipEngineException extends RuntimeException {
             String message,
             String source,
             String type,
-            String code
-    ) {
+            String code) {
         super(message);
         setSource(ErrorSource.valueOf(source.toUpperCase()));
         setType(ErrorType.valueOf(type.toUpperCase()));

--- a/src/main/java/com/shipengine/exception/ShipEngineException.java
+++ b/src/main/java/com/shipengine/exception/ShipEngineException.java
@@ -40,7 +40,9 @@ public class ShipEngineException extends RuntimeException {
         ERROR,
         SECURITY,
         SYSTEM,
-        VALIDATION
+        VALIDATION,
+        WALLET,
+        FUNDING_SOURCES
     }
 
     public enum ErrorCode {


### PR DESCRIPTION
There are some common errors while interacting with funding sources that are not handled correctly. Two of them are that when we throw a PreSetupWalletException or a WalletException we return a "An unexpected error occurred" instead of a more understandable error.
JIRA: https://auctane.atlassian.net/browse/ENGINE-7190
ShipEngine: https://github.com/shipstation/shipstation/pull/20482
SE Documentation: https://github.com/ShipEngine/shipengine-api-definition/pull/114